### PR TITLE
Version Packages (notify)

### DIFF
--- a/workspaces/notify/.changeset/busy-pets-sip.md
+++ b/workspaces/notify/.changeset/busy-pets-sip.md
@@ -1,5 +1,0 @@
----
-'@proberaum/backstage-plugin-github-notifications-backend': minor
----
-
-Initial version of the github-notifications plugin

--- a/workspaces/notify/plugins/github-notifications-backend/CHANGELOG.md
+++ b/workspaces/notify/plugins/github-notifications-backend/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @proberaum/backstage-plugin-github-notifications-backend
+
+## 0.1.0
+
+### Minor Changes
+
+- 097809f: Initial version of the github-notifications plugin

--- a/workspaces/notify/plugins/github-notifications-backend/package.json
+++ b/workspaces/notify/plugins/github-notifications-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proberaum/backstage-plugin-github-notifications-backend",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "license": "Apache-2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
# Releases

## @proberaum/backstage-plugin-github-notifications-backend@0.1.0

### Minor Changes

-   097809f: Initial version of the github-notifications plugin
