### PR TITLE
Version Packages (github-notifications)

### DIFF
--- a/workspaces/github-notifications/.changeset/petite-places-enjoy.md
+++ b/workspaces/github-notifications/.changeset/petite-places-enjoy.md
@@ -1,5 +1,0 @@
----
-'@proberaum/backstage-plugin-github-notifications-backend': minor
----
-
-Backstage upgrade to 1.36.1

--- a/workspaces/github-notifications/plugins/github-notifications-backend/CHANGELOG.md
+++ b/workspaces/github-notifications/plugins/github-notifications-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @proberaum/backstage-plugin-github-notifications-backend
 
+## 0.4.0
+
+### Minor Changes
+
+- bc48026: Backstage upgrade to 1.36.1
+
 ## 0.3.0
 
 ### Minor Changes

--- a/workspaces/github-notifications/plugins/github-notifications-backend/package.json
+++ b/workspaces/github-notifications/plugins/github-notifications-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proberaum/backstage-plugin-github-notifications-backend",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "license": "Apache-2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
# Releases

## @proberaum/backstage-plugin-github-notifications-backend@0.4.0

### Minor Changes

-   bc48026: Backstage upgrade to 1.36.1
