### PR TITLE
Version Packages (scheduler-notifications)

### DIFF
--- a/workspaces/scheduler-notifications/.changeset/many-tires-rule.md
+++ b/workspaces/scheduler-notifications/.changeset/many-tires-rule.md
@@ -1,7 +1,0 @@
----
-'@proberaum/backstage-plugin-catalog-backend-module-scheduler-notifications': patch
-'@proberaum/backstage-plugin-scheduler-notifications-backend': patch
-'@proberaum/backstage-plugin-scheduler-notifications-common': patch
----
-
-Initial version of the scheduler-notifications plugin

--- a/workspaces/scheduler-notifications/plugins/catalog-backend-module-scheduler-notifications/CHANGELOG.md
+++ b/workspaces/scheduler-notifications/plugins/catalog-backend-module-scheduler-notifications/CHANGELOG.md
@@ -1,0 +1,9 @@
+# @proberaum/backstage-plugin-catalog-backend-module-scheduler-notifications
+
+## 0.0.1
+
+### Patch Changes
+
+- d23c8a8: Initial version of the scheduler-notifications plugin
+- Updated dependencies [d23c8a8]
+  - @proberaum/backstage-plugin-scheduler-notifications-common@0.0.1

--- a/workspaces/scheduler-notifications/plugins/catalog-backend-module-scheduler-notifications/package.json
+++ b/workspaces/scheduler-notifications/plugins/catalog-backend-module-scheduler-notifications/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proberaum/backstage-plugin-catalog-backend-module-scheduler-notifications",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "license": "Apache-2.0",
   "description": "The scheduler-notifications backend module for the catalog plugin.",
   "main": "src/index.ts",

--- a/workspaces/scheduler-notifications/plugins/scheduler-notifications-backend/CHANGELOG.md
+++ b/workspaces/scheduler-notifications/plugins/scheduler-notifications-backend/CHANGELOG.md
@@ -1,0 +1,9 @@
+# @proberaum/backstage-plugin-scheduler-notifications-backend
+
+## 0.0.1
+
+### Patch Changes
+
+- d23c8a8: Initial version of the scheduler-notifications plugin
+- Updated dependencies [d23c8a8]
+  - @proberaum/backstage-plugin-scheduler-notifications-common@0.0.1

--- a/workspaces/scheduler-notifications/plugins/scheduler-notifications-backend/package.json
+++ b/workspaces/scheduler-notifications/plugins/scheduler-notifications-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proberaum/backstage-plugin-scheduler-notifications-backend",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "license": "Apache-2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/workspaces/scheduler-notifications/plugins/scheduler-notifications-common/CHANGELOG.md
+++ b/workspaces/scheduler-notifications/plugins/scheduler-notifications-common/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @proberaum/backstage-plugin-scheduler-notifications-common
+
+## 0.0.1
+
+### Patch Changes
+
+- d23c8a8: Initial version of the scheduler-notifications plugin

--- a/workspaces/scheduler-notifications/plugins/scheduler-notifications-common/package.json
+++ b/workspaces/scheduler-notifications/plugins/scheduler-notifications-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proberaum/backstage-plugin-scheduler-notifications-common",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "license": "Apache-2.0",
   "description": "Common functionalities for the scheduler-notifications plugin",
   "main": "src/index.ts",


### PR DESCRIPTION
# Releases

## @proberaum/backstage-plugin-catalog-backend-module-scheduler-notifications@0.0.1

### Patch Changes

-   d23c8a8: Initial version of the scheduler-notifications plugin
-   Updated dependencies [d23c8a8]
    -   @proberaum/backstage-plugin-scheduler-notifications-common@0.0.1

## @proberaum/backstage-plugin-scheduler-notifications-backend@0.0.1

### Patch Changes

-   d23c8a8: Initial version of the scheduler-notifications plugin
-   Updated dependencies [d23c8a8]
    -   @proberaum/backstage-plugin-scheduler-notifications-common@0.0.1

## @proberaum/backstage-plugin-scheduler-notifications-common@0.0.1

### Patch Changes

-   d23c8a8: Initial version of the scheduler-notifications plugin
