### PR TITLE
Version Packages (assets)

### DIFF
--- a/workspaces/assets/.changeset/metal-sides-marry.md
+++ b/workspaces/assets/.changeset/metal-sides-marry.md
@@ -1,8 +1,0 @@
----
-'@proberaum/backstage-plugin-catalog-backend-module-assets': minor
-'@proberaum/backstage-plugin-assets-backend': minor
-'@proberaum/backstage-plugin-assets-common': minor
-'@proberaum/backstage-plugin-assets': minor
----
-
-Backstage upgrade to 1.39.1

--- a/workspaces/assets/plugins/assets-backend/CHANGELOG.md
+++ b/workspaces/assets/plugins/assets-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @proberaum/backstage-plugin-assets-backend
 
+## 0.2.0
+
+### Minor Changes
+
+- 18ada83: Backstage upgrade to 1.39.1
+
 ## 0.1.0
 
 ### Minor Changes

--- a/workspaces/assets/plugins/assets-backend/package.json
+++ b/workspaces/assets/plugins/assets-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proberaum/backstage-plugin-assets-backend",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/assets/plugins/assets-common/CHANGELOG.md
+++ b/workspaces/assets/plugins/assets-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @proberaum/backstage-plugin-assets-common
 
+## 0.2.0
+
+### Minor Changes
+
+- 18ada83: Backstage upgrade to 1.39.1
+
 ## 0.1.0
 
 ### Minor Changes

--- a/workspaces/assets/plugins/assets-common/package.json
+++ b/workspaces/assets/plugins/assets-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@proberaum/backstage-plugin-assets-common",
   "description": "Common functionalities for the assets plugin",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/assets/plugins/assets/CHANGELOG.md
+++ b/workspaces/assets/plugins/assets/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @proberaum/backstage-plugin-assets
 
+## 0.2.0
+
+### Minor Changes
+
+- 18ada83: Backstage upgrade to 1.39.1
+
 ## 0.1.0
 
 ### Minor Changes

--- a/workspaces/assets/plugins/assets/package.json
+++ b/workspaces/assets/plugins/assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proberaum/backstage-plugin-assets",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/assets/plugins/catalog-backend-module-assets/CHANGELOG.md
+++ b/workspaces/assets/plugins/catalog-backend-module-assets/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @proberaum/backstage-plugin-catalog-backend-module-assets
 
+## 0.2.0
+
+### Minor Changes
+
+- 18ada83: Backstage upgrade to 1.39.1
+
 ## 0.1.0
 
 ### Minor Changes

--- a/workspaces/assets/plugins/catalog-backend-module-assets/package.json
+++ b/workspaces/assets/plugins/catalog-backend-module-assets/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@proberaum/backstage-plugin-catalog-backend-module-assets",
   "description": "The assets backend module for the catalog plugin.",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @proberaum/backstage-plugin-assets@0.2.0

### Minor Changes

-   18ada83: Backstage upgrade to 1.39.1

## @proberaum/backstage-plugin-assets-backend@0.2.0

### Minor Changes

-   18ada83: Backstage upgrade to 1.39.1

## @proberaum/backstage-plugin-assets-common@0.2.0

### Minor Changes

-   18ada83: Backstage upgrade to 1.39.1

## @proberaum/backstage-plugin-catalog-backend-module-assets@0.2.0

### Minor Changes

-   18ada83: Backstage upgrade to 1.39.1
