### PR TITLE
Version Packages (dashboards)

### DIFF
--- a/workspaces/dashboards/.changeset/six-buses-tie.md
+++ b/workspaces/dashboards/.changeset/six-buses-tie.md
@@ -1,7 +1,0 @@
----
-'@proberaum/backstage-plugin-dashboards-backend': minor
-'@proberaum/backstage-plugin-dashboards-common': minor
-'@proberaum/backstage-plugin-dashboards': minor
----
-
-Backstage upgrade to 1.39.1

--- a/workspaces/dashboards/plugins/dashboards-backend/CHANGELOG.md
+++ b/workspaces/dashboards/plugins/dashboards-backend/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @proberaum/backstage-plugin-dashboards-backend
 
+## 0.2.0
+
+### Minor Changes
+
+- 84c23ff: Backstage upgrade to 1.39.1
+
+### Patch Changes
+
+- Updated dependencies [84c23ff]
+  - @proberaum/backstage-plugin-dashboards-common@0.2.0
+
 ## 0.1.0
 
 ### Minor Changes

--- a/workspaces/dashboards/plugins/dashboards-backend/package.json
+++ b/workspaces/dashboards/plugins/dashboards-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proberaum/backstage-plugin-dashboards-backend",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/dashboards/plugins/dashboards-common/CHANGELOG.md
+++ b/workspaces/dashboards/plugins/dashboards-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @proberaum/backstage-plugin-dashboards-common
 
+## 0.2.0
+
+### Minor Changes
+
+- 84c23ff: Backstage upgrade to 1.39.1
+
 ## 0.1.0
 
 ### Minor Changes

--- a/workspaces/dashboards/plugins/dashboards-common/package.json
+++ b/workspaces/dashboards/plugins/dashboards-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@proberaum/backstage-plugin-dashboards-common",
   "description": "Common functionalities for the dashboards plugin",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/dashboards/plugins/dashboards/CHANGELOG.md
+++ b/workspaces/dashboards/plugins/dashboards/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @proberaum/backstage-plugin-dashboards
 
+## 0.2.0
+
+### Minor Changes
+
+- 84c23ff: Backstage upgrade to 1.39.1
+
+### Patch Changes
+
+- Updated dependencies [84c23ff]
+  - @proberaum/backstage-plugin-dashboards-common@0.2.0
+
 ## 0.1.0
 
 ### Minor Changes

--- a/workspaces/dashboards/plugins/dashboards/package.json
+++ b/workspaces/dashboards/plugins/dashboards/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proberaum/backstage-plugin-dashboards",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @proberaum/backstage-plugin-dashboards@0.2.0

### Minor Changes

-   84c23ff: Backstage upgrade to 1.39.1

### Patch Changes

-   Updated dependencies [84c23ff]
    -   @proberaum/backstage-plugin-dashboards-common@0.2.0

## @proberaum/backstage-plugin-dashboards-backend@0.2.0

### Minor Changes

-   84c23ff: Backstage upgrade to 1.39.1

### Patch Changes

-   Updated dependencies [84c23ff]
    -   @proberaum/backstage-plugin-dashboards-common@0.2.0

## @proberaum/backstage-plugin-dashboards-common@0.2.0

### Minor Changes

-   84c23ff: Backstage upgrade to 1.39.1
