### PR TITLE
Version Packages (scheduler-notifications)

### DIFF
--- a/workspaces/scheduler-notifications/.changeset/hip-flies-switch.md
+++ b/workspaces/scheduler-notifications/.changeset/hip-flies-switch.md
@@ -1,7 +1,0 @@
----
-'@proberaum/backstage-plugin-catalog-backend-module-scheduler-notifications': minor
-'@proberaum/backstage-plugin-scheduler-notifications-backend': minor
-'@proberaum/backstage-plugin-scheduler-notifications-common': minor
----
-
-Backstage upgrade to 1.44.1

--- a/workspaces/scheduler-notifications/plugins/catalog-backend-module-scheduler-notifications/CHANGELOG.md
+++ b/workspaces/scheduler-notifications/plugins/catalog-backend-module-scheduler-notifications/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @proberaum/backstage-plugin-catalog-backend-module-scheduler-notifications
 
+## 0.3.0
+
+### Minor Changes
+
+- 8648528: Backstage upgrade to 1.44.1
+
+### Patch Changes
+
+- Updated dependencies [8648528]
+  - @proberaum/backstage-plugin-scheduler-notifications-common@0.3.0
+
 ## 0.2.0
 
 ### Minor Changes

--- a/workspaces/scheduler-notifications/plugins/catalog-backend-module-scheduler-notifications/package.json
+++ b/workspaces/scheduler-notifications/plugins/catalog-backend-module-scheduler-notifications/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proberaum/backstage-plugin-catalog-backend-module-scheduler-notifications",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "Apache-2.0",
   "description": "The scheduler-notifications backend module for the catalog plugin.",
   "main": "src/index.ts",

--- a/workspaces/scheduler-notifications/plugins/scheduler-notifications-backend/CHANGELOG.md
+++ b/workspaces/scheduler-notifications/plugins/scheduler-notifications-backend/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @proberaum/backstage-plugin-scheduler-notifications-backend
 
+## 0.3.0
+
+### Minor Changes
+
+- 8648528: Backstage upgrade to 1.44.1
+
+### Patch Changes
+
+- Updated dependencies [8648528]
+  - @proberaum/backstage-plugin-scheduler-notifications-common@0.3.0
+
 ## 0.2.0
 
 ### Minor Changes

--- a/workspaces/scheduler-notifications/plugins/scheduler-notifications-backend/package.json
+++ b/workspaces/scheduler-notifications/plugins/scheduler-notifications-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proberaum/backstage-plugin-scheduler-notifications-backend",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "Apache-2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/workspaces/scheduler-notifications/plugins/scheduler-notifications-common/CHANGELOG.md
+++ b/workspaces/scheduler-notifications/plugins/scheduler-notifications-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @proberaum/backstage-plugin-scheduler-notifications-common
 
+## 0.3.0
+
+### Minor Changes
+
+- 8648528: Backstage upgrade to 1.44.1
+
 ## 0.2.0
 
 ### Minor Changes

--- a/workspaces/scheduler-notifications/plugins/scheduler-notifications-common/package.json
+++ b/workspaces/scheduler-notifications/plugins/scheduler-notifications-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proberaum/backstage-plugin-scheduler-notifications-common",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "Apache-2.0",
   "description": "Common functionalities for the scheduler-notifications plugin",
   "main": "src/index.ts",


### PR DESCRIPTION
# Releases

## @proberaum/backstage-plugin-catalog-backend-module-scheduler-notifications@0.3.0

### Minor Changes

-   8648528: Backstage upgrade to 1.44.1

### Patch Changes

-   Updated dependencies [8648528]
    -   @proberaum/backstage-plugin-scheduler-notifications-common@0.3.0

## @proberaum/backstage-plugin-scheduler-notifications-backend@0.3.0

### Minor Changes

-   8648528: Backstage upgrade to 1.44.1

### Patch Changes

-   Updated dependencies [8648528]
    -   @proberaum/backstage-plugin-scheduler-notifications-common@0.3.0

## @proberaum/backstage-plugin-scheduler-notifications-common@0.3.0

### Minor Changes

-   8648528: Backstage upgrade to 1.44.1
