### PR TITLE
feat(config-viewer): add backend to read backend files

### DIFF
--- a/workspaces/config-viewer/.changeset/olive-humans-sink.md
+++ b/workspaces/config-viewer/.changeset/olive-humans-sink.md
@@ -1,0 +1,6 @@
+---
+'@proberaum/backstage-plugin-config-viewer-backend': minor
+'@proberaum/backstage-plugin-config-viewer': minor
+---
+
+Add new backend to read backend files (optional feature)

--- a/workspaces/config-viewer/app-config.yaml
+++ b/workspaces/config-viewer/app-config.yaml
@@ -111,3 +111,15 @@ kubernetes:
 permission:
   # setting this to `false` will disable permissions
   enabled: true
+
+configViewer:
+  dangerouslyAnyoneCanReadAllTheFiles: true
+  workingDirectory: ../..
+  files:
+    - catalog-info.yaml
+    - package.json
+    - app-config.yaml
+    - app-config.*.yaml
+    - . # folders are not allowed!
+  ignore:
+    - catalog-info.yaml

--- a/workspaces/config-viewer/plugins/config-viewer-backend/config.d.ts
+++ b/workspaces/config-viewer/plugins/config-viewer-backend/config.d.ts
@@ -1,0 +1,10 @@
+export interface ConfigViewerConfig {
+  dangerouslyAnyoneCanReadAllTheFiles?: boolean;
+  workingDirectory?: string;
+  files: string[];
+  ignore?: string[];
+}
+
+export interface Config {
+  configViewer?: ConfigViewerConfig;
+}

--- a/workspaces/config-viewer/plugins/config-viewer-backend/package.json
+++ b/workspaces/config-viewer/plugins/config-viewer-backend/package.json
@@ -2,7 +2,6 @@
   "name": "@proberaum/backstage-plugin-config-viewer-backend",
   "version": "0.0.0",
   "license": "Apache-2.0",
-  "private": true,
   "main": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {
@@ -40,6 +39,7 @@
     "@backstage/plugin-catalog-node": "^1.19.1",
     "express": "^4.17.1",
     "express-promise-router": "^4.1.0",
+    "glob": "^11.0.3",
     "zod": "^3.22.4"
   },
   "devDependencies": {

--- a/workspaces/config-viewer/plugins/config-viewer-backend/src/plugin.test.ts
+++ b/workspaces/config-viewer/plugins/config-viewer-backend/src/plugin.test.ts
@@ -1,85 +1,29 @@
-import {
-  mockCredentials,
-  startTestBackend,
-} from '@backstage/backend-test-utils';
+import { mockServices, startTestBackend } from '@backstage/backend-test-utils';
 import { configViewerPlugin } from './plugin';
 import request from 'supertest';
-import { catalogServiceMock } from '@backstage/plugin-catalog-node/testUtils';
 
-// TEMPLATE NOTE:
-// Plugin tests are integration tests for your plugin, ensuring that all pieces
-// work together end-to-end. You can still mock injected backend services
-// however, just like anyone who installs your plugin might replace the
-// services with their own implementations.
 describe('plugin', () => {
-  it('should create and read TODO items', async () => {
-    const { server } = await startTestBackend({
-      features: [configViewerPlugin],
-    });
-
-    await request(server).get('/api/config-viewer/todos').expect(200, {
-      items: [],
-    });
-
-    const createRes = await request(server)
-      .post('/api/config-viewer/todos')
-      .send({ title: 'My Todo' });
-
-    expect(createRes.status).toBe(201);
-    expect(createRes.body).toEqual({
-      id: expect.any(String),
-      title: 'My Todo',
-      createdBy: mockCredentials.user().principal.userEntityRef,
-      createdAt: expect.any(String),
-    });
-
-    const createdTodoItem = createRes.body;
-
-    await request(server)
-      .get('/api/config-viewer/todos')
-      .expect(200, {
-        items: [createdTodoItem],
-      });
-
-    await request(server)
-      .get(`/api/config-viewer/todos/${createdTodoItem.id}`)
-      .expect(200, createdTodoItem);
-  });
-
-  it('should create TODO item with catalog information', async () => {
+  it('should return files', async () => {
     const { server } = await startTestBackend({
       features: [
-        configViewerPlugin,
-        catalogServiceMock.factory({
-          entities: [
-            {
-              apiVersion: 'backstage.io/v1alpha1',
-              kind: 'Component',
-              metadata: {
-                name: 'my-component',
-                namespace: 'default',
-                title: 'My Component',
-              },
-              spec: {
-                type: 'service',
-                owner: 'me',
-              },
+        mockServices.rootConfig.factory({
+          data: {
+            configViewer: {
+              dangerouslyAnyoneCanReadAllTheFiles: true,
+              files: ['app-config.yaml', 'app-config.prod*.yaml'],
             },
-          ],
+          },
         }),
+        configViewerPlugin,
       ],
     });
 
-    const createRes = await request(server)
-      .post('/api/config-viewer/todos')
-      .send({ title: 'My Todo', entityRef: 'component:default/my-component' });
+    const response = await request(server).get('/api/config-viewer/files');
 
-    expect(createRes.status).toBe(201);
-    expect(createRes.body).toEqual({
-      id: expect.any(String),
-      title: '[My Component] My Todo',
-      createdBy: mockCredentials.user().principal.userEntityRef,
-      createdAt: expect.any(String),
-    });
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual([
+      'app-config.production.yaml',
+      'app-config.yaml',
+    ]);
   });
 });

--- a/workspaces/config-viewer/plugins/config-viewer-backend/src/plugin.ts
+++ b/workspaces/config-viewer/plugins/config-viewer-backend/src/plugin.ts
@@ -2,9 +2,9 @@ import {
   coreServices,
   createBackendPlugin,
 } from '@backstage/backend-plugin-api';
+
+import type { ConfigViewerConfig } from '../config';
 import { createRouter } from './router';
-import { catalogServiceRef } from '@backstage/plugin-catalog-node';
-import { createTodoListService } from './services/TodoListService';
 
 /**
  * configViewerPlugin backend plugin
@@ -16,21 +16,23 @@ export const configViewerPlugin = createBackendPlugin({
   register(env) {
     env.registerInit({
       deps: {
+        rootConfig: coreServices.rootConfig,
         logger: coreServices.logger,
-        httpAuth: coreServices.httpAuth,
+        // httpAuth: coreServices.httpAuth,
         httpRouter: coreServices.httpRouter,
-        catalog: catalogServiceRef,
       },
-      async init({ logger, httpAuth, httpRouter, catalog }) {
-        const todoListService = await createTodoListService({
-          logger,
-          catalog,
-        });
+      async init({ rootConfig, /*httpAuth,*/ httpRouter }) {
+        const config =
+          rootConfig.getOptional<ConfigViewerConfig>('configViewer');
+
+        if (!config) {
+          return;
+        }
 
         httpRouter.use(
           await createRouter({
-            httpAuth,
-            todoListService,
+            config,
+            // httpAuth,
           }),
         );
       },

--- a/workspaces/config-viewer/plugins/config-viewer-backend/src/router.test.ts
+++ b/workspaces/config-viewer/plugins/config-viewer-backend/src/router.test.ts
@@ -1,67 +1,36 @@
 import {
   mockCredentials,
   mockErrorHandler,
-  mockServices,
+  // mockServices,
 } from '@backstage/backend-test-utils';
 import express from 'express';
 import request from 'supertest';
 
 import { createRouter } from './router';
-import { TodoListService } from './services/TodoListService/types';
 
-const mockTodoItem = {
-  title: 'Do the thing',
-  id: '123',
-  createdBy: mockCredentials.user().principal.userEntityRef,
-  createdAt: new Date().toISOString(),
-};
-
-// TEMPLATE NOTE:
-// Testing the router directly allows you to write a unit test that mocks the provided options.
 describe('createRouter', () => {
   let app: express.Express;
-  let todoListService: jest.Mocked<TodoListService>;
 
-  beforeEach(async () => {
-    todoListService = {
-      createTodo: jest.fn(),
-      listTodos: jest.fn(),
-      getTodo: jest.fn(),
-    };
+  it('should return files', async () => {
     const router = await createRouter({
-      httpAuth: mockServices.httpAuth(),
-      todoListService,
+      config: {
+        dangerouslyAnyoneCanReadAllTheFiles: true,
+        files: ['app-config.yaml', 'app-config.prod*.yaml'],
+      },
+      // httpAuth: mockServices.httpAuth(),
     });
     app = express();
     app.use(router);
     app.use(mockErrorHandler());
-  });
 
-  it('should create a TODO', async () => {
-    todoListService.createTodo.mockResolvedValue(mockTodoItem);
-
-    const response = await request(app).post('/todos').send({
-      title: 'Do the thing',
-    });
-
-    expect(response.status).toBe(201);
-    expect(response.body).toEqual(mockTodoItem);
-  });
-
-  it('should not allow unauthenticated requests to create a TODO', async () => {
-    todoListService.createTodo.mockResolvedValue(mockTodoItem);
-
-    // TEMPLATE NOTE:
-    // The HttpAuth mock service considers all requests to be authenticated as a
-    // mock user by default. In order to test other cases we need to explicitly
-    // pass an authorization header with mock credentials.
     const response = await request(app)
-      .post('/todos')
-      .set('Authorization', mockCredentials.none.header())
-      .send({
-        title: 'Do the thing',
-      });
+      .get('/files')
+      .set('Authorization', mockCredentials.none.header());
 
-    expect(response.status).toBe(401);
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual([
+      'app-config.production.yaml',
+      'app-config.yaml',
+    ]);
   });
 });

--- a/workspaces/config-viewer/plugins/config-viewer/report.api.md
+++ b/workspaces/config-viewer/plugins/config-viewer/report.api.md
@@ -26,6 +26,8 @@ export const configViewerTranslationRef: TranslationRef<
   'plugin.config-viewer.translation-ref',
   {
     readonly 'page.title': 'Config viewer';
+    readonly 'page.subtitleWithoutAppTitle': 'Inspect configuration files';
+    readonly 'page.subtitleWithAppTitle': 'Inspect configuration files of {{appTitle}}';
     readonly 'sidebar.title': 'Config viewer';
     readonly 'common.filterPlaceholder': 'Filter config keys';
   }

--- a/workspaces/config-viewer/plugins/config-viewer/src/components/ConfigViewerContent.tsx
+++ b/workspaces/config-viewer/plugins/config-viewer/src/components/ConfigViewerContent.tsx
@@ -1,15 +1,24 @@
-import { useMemo } from 'react';
+import { Key, useMemo } from 'react';
+import { useLocation } from 'react-router-dom';
+
 import { CodeSnippet, useQueryParamState } from '@backstage/core-components';
 import { useApi, configApiRef } from '@backstage/core-plugin-api';
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
-import { SearchField } from '@backstage/ui';
+import { Tabs, TabList, Tab, SearchField } from '@backstage/ui';
 
 import YAML from 'yaml';
 
 import { configViewerTranslationRef } from '../translations';
+import { useFiles } from '../hooks/useFiles';
+import { useFileContent } from '../hooks/useFileContent';
+
+const frontendTabKey: Key = '__frontend';
 
 export const ConfigViewerContent = () => {
   const { t } = useTranslationRef(configViewerTranslationRef);
+
+  const files = useFiles();
+
   const [searchTerm, setSearchTerm] = useQueryParamState<string | undefined>(
     'q',
   );
@@ -21,19 +30,48 @@ export const ConfigViewerContent = () => {
   const config = configApi.get();
   const yaml = YAML.stringify(config);
 
+  const [filename] = useQueryParamState<string | undefined>('filename');
+  const fileContent = useFileContent(filename);
+
   const filteredYaml = useMemo(() => {
+    const selectedYaml = filename ? fileContent : yaml;
     if (!searchTerm) {
-      return yaml;
+      return selectedYaml;
     }
     const lowerCasedTerm = searchTerm.toLocaleLowerCase('en');
-    return yaml
+    return selectedYaml
       .split('\n')
       .filter(line => line.toLocaleLowerCase('en').includes(lowerCasedTerm))
       .join('\n');
-  }, [searchTerm, yaml]);
+  }, [searchTerm, yaml, filename, fileContent]);
+
+  const location = useLocation();
+  const searchParams = new URLSearchParams(location.search);
+  searchParams.delete('filename');
 
   return (
     <>
+      {files && files.length > 0 ? (
+        <>
+          <Tabs selectedKey={filename ?? frontendTabKey}>
+            <TabList>
+              <Tab id={frontendTabKey} href={`?${searchParams}`}>
+                Frontend config
+              </Tab>
+              {files.map(file => {
+                searchParams.set('filename', file);
+                return (
+                  <Tab key={file} id={file} href={`?${searchParams}`}>
+                    {file}
+                  </Tab>
+                );
+              })}
+            </TabList>
+          </Tabs>
+          <br />
+        </>
+      ) : null}
+
       <SearchField
         placeholder={t('common.filterPlaceholder')}
         defaultValue={searchTerm}

--- a/workspaces/config-viewer/plugins/config-viewer/src/components/ConfigViewerPage.tsx
+++ b/workspaces/config-viewer/plugins/config-viewer/src/components/ConfigViewerPage.tsx
@@ -4,13 +4,19 @@ import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 import { configViewerTranslationRef } from '../translations';
 
 import { ConfigViewerContent } from './ConfigViewerContent';
+import { configApiRef, useApi } from '@backstage/core-plugin-api';
 
 export const ConfigViewerPage = () => {
   const { t } = useTranslationRef(configViewerTranslationRef);
+  const appTitle = useApi(configApiRef).getOptionalString('app.title');
+  const pageTitle = t('page.title');
+  const pageSubtitle = appTitle
+    ? t('page.subtitleWithAppTitle', { appTitle })
+    : t('page.subtitleWithoutAppTitle');
 
   return (
     <Page themeId="tool">
-      <Header title={t('page.title')} />
+      <Header title={pageTitle} subtitle={pageSubtitle} />
       <Content>
         <ConfigViewerContent />
       </Content>

--- a/workspaces/config-viewer/plugins/config-viewer/src/hooks/useFileContent.ts
+++ b/workspaces/config-viewer/plugins/config-viewer/src/hooks/useFileContent.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react';
+
+import {
+  discoveryApiRef,
+  fetchApiRef,
+  useApi,
+} from '@backstage/core-plugin-api';
+
+export const useFileContent = (filename: string | undefined) => {
+  const discoveryApi = useApi(discoveryApiRef);
+  const fetchApi = useApi(fetchApiRef);
+  const [fileContent, setFileContent] = useState<string>('');
+  useEffect(() => {
+    if (!filename) {
+      return;
+    }
+    (async () => {
+      try {
+        const baseUrl = await discoveryApi.getBaseUrl('config-viewer');
+        const response = await fetchApi.fetch(
+          `${baseUrl}/content?filename=${filename}`,
+        );
+        if (!response.ok) {
+          throw new Error();
+        }
+        const content = await response.text();
+        setFileContent(content);
+      } catch (error) {
+        console.warn('error', error);
+      }
+    })();
+  }, [filename]);
+  return fileContent;
+};

--- a/workspaces/config-viewer/plugins/config-viewer/src/hooks/useFiles.ts
+++ b/workspaces/config-viewer/plugins/config-viewer/src/hooks/useFiles.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react';
+
+import {
+  discoveryApiRef,
+  fetchApiRef,
+  useApi,
+} from '@backstage/core-plugin-api';
+
+export const useFiles = () => {
+  const discoveryApi = useApi(discoveryApiRef);
+  const fetchApi = useApi(fetchApiRef);
+  const [files, setFiles] = useState<string[]>();
+  useEffect(() => {
+    (async () => {
+      try {
+        const baseUrl = await discoveryApi.getBaseUrl('config-viewer');
+        const response = await fetchApi.fetch(`${baseUrl}/files`);
+        if (!response.ok) {
+          throw new Error();
+        }
+        const json = await response.json();
+        setFiles(json);
+      } catch (error) {
+        console.warn('error', error);
+      }
+    })();
+  }, []);
+  return files;
+};

--- a/workspaces/config-viewer/plugins/config-viewer/src/translations/de.ts
+++ b/workspaces/config-viewer/plugins/config-viewer/src/translations/de.ts
@@ -8,6 +8,9 @@ const de = createTranslationMessages({
   messages: {
     'sidebar.title': 'Konfiguration',
     'page.title': 'Konfiguration',
+    'page.subtitleWithoutAppTitle': 'Einsicht in Konfigurationsdateien',
+    'page.subtitleWithAppTitle':
+      'Einsicht in Konfigurationsdateien von {{appTitle}}',
     'common.filterPlaceholder': 'Konfiguration filtern',
   },
 });

--- a/workspaces/config-viewer/plugins/config-viewer/src/translations/ref.ts
+++ b/workspaces/config-viewer/plugins/config-viewer/src/translations/ref.ts
@@ -11,6 +11,8 @@ export const configViewerTranslationRef = createTranslationRef({
     },
     page: {
       title: 'Config viewer',
+      subtitleWithoutAppTitle: 'Inspect configuration files',
+      subtitleWithAppTitle: 'Inspect configuration files of {{appTitle}}',
     },
     common: {
       filterPlaceholder: 'Filter config keys',

--- a/workspaces/config-viewer/yarn.lock
+++ b/workspaces/config-viewer/yarn.lock
@@ -8619,6 +8619,7 @@ __metadata:
     "@types/supertest": "npm:^2.0.12"
     express: "npm:^4.17.1"
     express-promise-router: "npm:^4.1.0"
+    glob: "npm:^11.0.3"
     supertest: "npm:^6.2.4"
     zod: "npm:^3.22.4"
   languageName: unknown
@@ -21029,7 +21030,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:11.0.3":
+"glob@npm:11.0.3, glob@npm:^11.0.3":
   version: 11.0.3
   resolution: "glob@npm:11.0.3"
   dependencies:


### PR DESCRIPTION
Add new backend to read backend files as an optional feature!

There is no permission framework integration yet but it requires an `dangerouslyAnyoneCanReadAllTheFiles` opt-in for now:

```yaml
configViewer:
  dangerouslyAnyoneCanReadAllTheFiles: true
  workingDirectory: ../..
  files:
    - catalog-info.yaml
    - package.json
    - app-config.yaml
    - app-config.*.yaml
    - . # folders are not allowed!
  ignore:
    - catalog-info.yaml
```

<img width="1770" height="693" alt="image" src="https://github.com/user-attachments/assets/da6514fd-80ef-404b-9598-c6532258dc07" />
